### PR TITLE
Issue 28 - added an export of rankings for cross-listing with mutations

### DIFF
--- a/applications/forny_2023/predict_driver_mutations.ipynb
+++ b/applications/forny_2023/predict_driver_mutations.ipynb
@@ -834,7 +834,7 @@
             "INFO:httpx:HTTP Request: HEAD https://huggingface.co/api/resolve-cache/datasets/seanhacks/relation_prediction/8898e2d98f7c6113e696e944a964b6c766520a10/registry.json \"HTTP/1.1 200 OK\"\n",
             "INFO:napistu_torch.ml.hugging_face:✓ Downloaded registry.json to /Users/sean/Desktop/DATA/Forny2023/cache/.store/registry.json\n",
             "INFO:napistu_torch.ml.hugging_face:Downloading 7 artifact files...\n",
-            "Downloading artifacts: 100%|██████████| 7/7 [00:00<00:00, 8492.95it/s]\n",
+            "Downloading artifacts: 100%|██████████| 7/7 [00:00<00:00, 10215.77it/s]\n",
             "INFO:napistu_torch.ml.hugging_face:✓ Downloaded 7 artifact files\n",
             "WARNING:napistu_torch.utils.base_utils:base_utils.ensure_path is deprecated, use napistu.utils.base_utils.ensure_path instead\n",
             "WARNING:napistu_torch.utils.base_utils:base_utils.ensure_path is deprecated, use napistu.utils.base_utils.ensure_path instead\n",
@@ -890,6 +890,7 @@
             "WARNING:napistu_torch.utils.base_utils:base_utils.ensure_path is deprecated, use napistu.utils.base_utils.ensure_path instead\n",
             "INFO:httpx:HTTP Request: GET https://huggingface.co/api/models/seanhacks/edge_prediction_mlp_256e \"HTTP/1.1 200 OK\"\n",
             "INFO:httpx:HTTP Request: HEAD https://huggingface.co/seanhacks/edge_prediction_mlp_256e/resolve/main/config.json \"HTTP/1.1 307 Temporary Redirect\"\n",
+            "INFO:httpx:HTTP Request: HEAD https://huggingface.co/api/resolve-cache/models/seanhacks/edge_prediction_mlp_256e/9ed12a9a7d13370a7664ddff2959b4e99813b110/config.json \"HTTP/1.1 200 OK\"\n",
             "INFO:napistu_torch.ml.hugging_face:Config available at: /Users/sean/.cache/huggingface/hub/models--seanhacks--edge_prediction_mlp_256e/snapshots/9ed12a9a7d13370a7664ddff2959b4e99813b110/config.json (using default cache)\n",
             "INFO:napistu_torch.evaluation.manager:Loading existing data store from .store\n",
             "WARNING:napistu_torch.utils.base_utils:base_utils.ensure_path is deprecated, use napistu.utils.base_utils.ensure_path instead\n",
@@ -903,15 +904,15 @@
             "INFO:napistu_torch.lightning.datamodule:Creating/loading store from config\n",
             "INFO:napistu_torch.napistu_data_store:Loading existing store from .store\n",
             "WARNING:napistu_torch.utils.base_utils:base_utils.ensure_path is deprecated, use napistu.utils.base_utils.ensure_path instead\n",
-            "INFO:napistu_torch.napistu_data_store:Ensuring required artifacts exist: ['edge_strata_by_node_type', 'relation_prediction', 'edge_strata_by_node_species_type', 'comprehensive_pathway_memberships']\n",
+            "INFO:napistu_torch.napistu_data_store:Ensuring required artifacts exist: ['edge_strata_by_node_type', 'relation_prediction', 'comprehensive_pathway_memberships', 'edge_strata_by_node_species_type']\n",
             "INFO:napistu_torch.napistu_data_store:All requested artifacts already exist in store\n",
             "INFO:napistu_torch.napistu_data_store:All requested artifacts already exist in store\n",
             "INFO:napistu_torch.lightning.datamodule:Loading napistu_data 'relation_prediction' from store\n",
             "INFO:napistu_torch.napistu_data_store:Loading NapistuData from .store/napistu_data/relation_prediction.pt\n",
             "WARNING:napistu_torch.utils.base_utils:base_utils.ensure_path is deprecated, use napistu.utils.base_utils.ensure_path instead\n",
             "INFO:napistu_torch.napistu_data_store:Loading pandas DataFrame from .store/pandas_dfs/edge_strata_by_node_type.parquet\n",
-            "INFO:napistu_torch.napistu_data_store:Loading pandas DataFrame from .store/pandas_dfs/edge_strata_by_node_species_type.parquet\n",
             "INFO:napistu_torch.napistu_data_store:Loading VertexTensor from .store/vertex_tensors/comprehensive_pathway_memberships.pt\n",
+            "INFO:napistu_torch.napistu_data_store:Loading pandas DataFrame from .store/pandas_dfs/edge_strata_by_node_species_type.parquet\n",
             "INFO:napistu_torch.lightning.edge_batch_datamodule:EdgeBatchDataModule initialized:\n",
             "  Total training edges: 6,420,899\n",
             "  Mini-batches per epoch: 20\n",
@@ -1004,7 +1005,7 @@
             "dtype: object\n",
             "INFO:__main__:Resolving many-to-one (multiple genes → same s_id) and one-to-many (gene → multiple s_ids) degeneracy\n",
             "INFO:__main__:Adding feature abundances to graph\n",
-            "WARNING:napistu.network.ng_core:entity_data contains 508 vertices ID(s) not in the graph: ['S00022332', 'S00032004', 'S00035443', 'S00000136', 'S00032068'] .... Filter entity_data to only include vertices present in the graph, or ensure the graph was not filtered (e.g. filter_by_species_type) before adding.\n",
+            "WARNING:napistu.network.ng_core:entity_data contains 508 vertices ID(s) not in the graph: ['S00002714', 'S00032387', 'S00022549', 'S00022811', 'S00032203'] .... Filter entity_data to only include vertices present in the graph, or ensure the graph was not filtered (e.g. filter_by_species_type) before adding.\n",
             "INFO:napistu.network.ng_core:Added 203 vertex attributes to graph: ['transcriptomics_MMA001', 'transcriptomics_MMA002', 'transcriptomics_MMA003', 'transcriptomics_MMA004', 'transcriptomics_MMA005', 'transcriptomics_MMA006', 'transcriptomics_MMA007', 'transcriptomics_MMA008', 'transcriptomics_MMA009', 'transcriptomics_MMA010', 'transcriptomics_MMA011', 'transcriptomics_MMA012', 'transcriptomics_MMA013', 'transcriptomics_MMA014', 'transcriptomics_MMA015', 'transcriptomics_MMA016', 'transcriptomics_MMA017', 'transcriptomics_MMA018', 'transcriptomics_MMA019', 'transcriptomics_MMA020', 'transcriptomics_MMA021', 'transcriptomics_MMA023', 'transcriptomics_MMA024', 'transcriptomics_MMA025', 'transcriptomics_MMA026', 'transcriptomics_MMA027', 'transcriptomics_MMA028', 'transcriptomics_MMA029', 'transcriptomics_MMA030', 'transcriptomics_MMA031', 'transcriptomics_MMA032', 'transcriptomics_MMA033', 'transcriptomics_MMA034', 'transcriptomics_MMA035', 'transcriptomics_MMA036', 'transcriptomics_MMA037', 'transcriptomics_MMA038', 'transcriptomics_MMA039', 'transcriptomics_MMA040', 'transcriptomics_MMA041', 'transcriptomics_MMA042', 'transcriptomics_MMA043', 'transcriptomics_MMA044', 'transcriptomics_MMA045', 'transcriptomics_MMA046', 'transcriptomics_MMA047', 'transcriptomics_MMA048', 'transcriptomics_MMA049', 'transcriptomics_MMA050', 'transcriptomics_MMA051', 'transcriptomics_MMA052', 'transcriptomics_MMA053', 'transcriptomics_MMA055', 'transcriptomics_MMA056', 'transcriptomics_MMA057', 'transcriptomics_MMA058', 'transcriptomics_MMA060', 'transcriptomics_MMA061', 'transcriptomics_MMA062', 'transcriptomics_MMA063', 'transcriptomics_MMA064', 'transcriptomics_MMA065', 'transcriptomics_MMA066', 'transcriptomics_MMA067', 'transcriptomics_MMA068', 'transcriptomics_MMA069', 'transcriptomics_MMA070', 'transcriptomics_MMA071', 'transcriptomics_MMA072', 'transcriptomics_MMA073', 'transcriptomics_MMA074', 'transcriptomics_MMA075', 'transcriptomics_MMA076', 'transcriptomics_MMA077', 'transcriptomics_MMA079', 'transcriptomics_MMA080', 'transcriptomics_MMA081', 'transcriptomics_MMA082', 'transcriptomics_MMA083', 'transcriptomics_MMA084', 'transcriptomics_MMA085', 'transcriptomics_MMA086', 'transcriptomics_MMA087', 'transcriptomics_MMA088', 'transcriptomics_MMA090', 'transcriptomics_MMA091', 'transcriptomics_MMA092', 'transcriptomics_MMA093', 'transcriptomics_MMA094', 'transcriptomics_MMA095', 'transcriptomics_MMA096', 'transcriptomics_MMA097', 'transcriptomics_MMA098', 'transcriptomics_MMA099', 'transcriptomics_MMA100', 'transcriptomics_MMA101', 'transcriptomics_MMA102', 'transcriptomics_MMA103', 'transcriptomics_MMA104', 'transcriptomics_MMA105', 'transcriptomics_MMA106', 'transcriptomics_MMA107', 'transcriptomics_MMA108', 'transcriptomics_MMA110', 'transcriptomics_MMA111', 'transcriptomics_MMA112', 'transcriptomics_MMA113', 'transcriptomics_MMA114', 'transcriptomics_MMA115', 'transcriptomics_MMA116', 'transcriptomics_MMA117', 'transcriptomics_MMA118', 'transcriptomics_MMA119', 'transcriptomics_MMA120', 'transcriptomics_MMA121', 'transcriptomics_MMA122', 'transcriptomics_MMA124', 'transcriptomics_MMA125', 'transcriptomics_MMA126', 'transcriptomics_MMA127', 'transcriptomics_MMA128', 'transcriptomics_MMA129', 'transcriptomics_MMA130', 'transcriptomics_MMA131', 'transcriptomics_MMA132', 'transcriptomics_MMA133', 'transcriptomics_MMA134', 'transcriptomics_MMA135', 'transcriptomics_MMA136', 'transcriptomics_MMA137', 'transcriptomics_MMA138', 'transcriptomics_MMA139', 'transcriptomics_MMA140', 'transcriptomics_MMA141', 'transcriptomics_MMA142', 'transcriptomics_MMA143', 'transcriptomics_MMA144', 'transcriptomics_MMA145', 'transcriptomics_MMA146', 'transcriptomics_MMA147', 'transcriptomics_MMA148', 'transcriptomics_MMA149', 'transcriptomics_MMA150', 'transcriptomics_MMA151', 'transcriptomics_MMA152', 'transcriptomics_MMA153', 'transcriptomics_MMA154', 'transcriptomics_MMA155', 'transcriptomics_MMA156', 'transcriptomics_MMA157', 'transcriptomics_MMA158', 'transcriptomics_MMA159', 'transcriptomics_MMA160', 'transcriptomics_MMA161', 'transcriptomics_MMA162', 'transcriptomics_MMA163', 'transcriptomics_MMA164', 'transcriptomics_MMA165', 'transcriptomics_MMA166', 'transcriptomics_MMA167', 'transcriptomics_MMA168', 'transcriptomics_MMA169', 'transcriptomics_MMA170', 'transcriptomics_MMA171', 'transcriptomics_MMA172', 'transcriptomics_MMA173', 'transcriptomics_MMA174', 'transcriptomics_MMA175', 'transcriptomics_MMA176', 'transcriptomics_MMA177', 'transcriptomics_MMA178', 'transcriptomics_MMA179', 'transcriptomics_MMA180', 'transcriptomics_MMA181', 'transcriptomics_MMA182', 'transcriptomics_MMA183', 'transcriptomics_MMA184', 'transcriptomics_MMA185', 'transcriptomics_MMA186', 'transcriptomics_MMA187', 'transcriptomics_MMA188', 'transcriptomics_MMA189', 'transcriptomics_MMA190', 'transcriptomics_MMA191', 'transcriptomics_MMA192', 'transcriptomics_MMA193', 'transcriptomics_MMA194', 'transcriptomics_MMA195', 'transcriptomics_MMA196', 'transcriptomics_MMA197', 'transcriptomics_MMA198', 'transcriptomics_MMA199', 'transcriptomics_MMA200', 'transcriptomics_MMA201', 'transcriptomics_MMA202', 'transcriptomics_MMA203', 'transcriptomics_MMA204', 'transcriptomics_MMA205', 'transcriptomics_MMA206', 'transcriptomics_MMA208', 'transcriptomics_MMA209', 'transcriptomics_MMA210', 'is_transcriptomics']\n",
             "INFO:__main__:Done\n",
             "INFO:__main__:Matching features to pathway species\n",
@@ -1026,7 +1027,7 @@
             "dtype: object\n",
             "INFO:__main__:Resolving many-to-one (multiple genes → same s_id) and one-to-many (gene → multiple s_ids) degeneracy\n",
             "INFO:__main__:Adding feature abundances to graph\n",
-            "WARNING:napistu.network.ng_core:entity_data contains 2658 vertices ID(s) not in the graph: ['S00026837', 'S00028908', 'S00027695', 'S00034862', 'S00024775'] .... Filter entity_data to only include vertices present in the graph, or ensure the graph was not filtered (e.g. filter_by_species_type) before adding.\n",
+            "WARNING:napistu.network.ng_core:entity_data contains 2658 vertices ID(s) not in the graph: ['S00024146', 'S00026946', 'S00032760', 'S00033064', 'S00025429'] .... Filter entity_data to only include vertices present in the graph, or ensure the graph was not filtered (e.g. filter_by_species_type) before adding.\n",
             "INFO:napistu.network.ng_core:Added 211 vertex attributes to graph: ['proteomics_MMA001', 'proteomics_MMA002', 'proteomics_MMA003', 'proteomics_MMA004', 'proteomics_MMA005', 'proteomics_MMA006', 'proteomics_MMA007', 'proteomics_MMA008', 'proteomics_MMA009', 'proteomics_MMA010', 'proteomics_MMA011', 'proteomics_MMA012', 'proteomics_MMA013', 'proteomics_MMA014', 'proteomics_MMA015', 'proteomics_MMA016', 'proteomics_MMA017', 'proteomics_MMA018', 'proteomics_MMA019', 'proteomics_MMA020', 'proteomics_MMA021', 'proteomics_MMA022', 'proteomics_MMA023', 'proteomics_MMA024', 'proteomics_MMA025', 'proteomics_MMA026', 'proteomics_MMA027', 'proteomics_MMA028', 'proteomics_MMA029', 'proteomics_MMA030', 'proteomics_MMA031', 'proteomics_MMA032', 'proteomics_MMA033', 'proteomics_MMA034', 'proteomics_MMA035', 'proteomics_MMA036', 'proteomics_MMA037', 'proteomics_MMA038', 'proteomics_MMA039', 'proteomics_MMA040', 'proteomics_MMA041', 'proteomics_MMA042', 'proteomics_MMA043', 'proteomics_MMA044', 'proteomics_MMA045', 'proteomics_MMA046', 'proteomics_MMA047', 'proteomics_MMA048', 'proteomics_MMA049', 'proteomics_MMA050', 'proteomics_MMA051', 'proteomics_MMA052', 'proteomics_MMA053', 'proteomics_MMA054', 'proteomics_MMA055', 'proteomics_MMA056', 'proteomics_MMA057', 'proteomics_MMA058', 'proteomics_MMA059', 'proteomics_MMA060', 'proteomics_MMA061', 'proteomics_MMA062', 'proteomics_MMA063', 'proteomics_MMA064', 'proteomics_MMA065', 'proteomics_MMA066', 'proteomics_MMA067', 'proteomics_MMA068', 'proteomics_MMA069', 'proteomics_MMA070', 'proteomics_MMA071', 'proteomics_MMA072', 'proteomics_MMA073', 'proteomics_MMA074', 'proteomics_MMA075', 'proteomics_MMA076', 'proteomics_MMA077', 'proteomics_MMA078', 'proteomics_MMA079', 'proteomics_MMA080', 'proteomics_MMA081', 'proteomics_MMA082', 'proteomics_MMA083', 'proteomics_MMA084', 'proteomics_MMA085', 'proteomics_MMA086', 'proteomics_MMA087', 'proteomics_MMA088', 'proteomics_MMA089', 'proteomics_MMA090', 'proteomics_MMA091', 'proteomics_MMA092', 'proteomics_MMA093', 'proteomics_MMA094', 'proteomics_MMA095', 'proteomics_MMA096', 'proteomics_MMA097', 'proteomics_MMA098', 'proteomics_MMA099', 'proteomics_MMA100', 'proteomics_MMA101', 'proteomics_MMA102', 'proteomics_MMA103', 'proteomics_MMA104', 'proteomics_MMA105', 'proteomics_MMA106', 'proteomics_MMA107', 'proteomics_MMA108', 'proteomics_MMA109', 'proteomics_MMA110', 'proteomics_MMA111', 'proteomics_MMA112', 'proteomics_MMA113', 'proteomics_MMA114', 'proteomics_MMA115', 'proteomics_MMA116', 'proteomics_MMA117', 'proteomics_MMA118', 'proteomics_MMA119', 'proteomics_MMA120', 'proteomics_MMA121', 'proteomics_MMA122', 'proteomics_MMA123', 'proteomics_MMA124', 'proteomics_MMA125', 'proteomics_MMA126', 'proteomics_MMA127', 'proteomics_MMA128', 'proteomics_MMA129', 'proteomics_MMA130', 'proteomics_MMA131', 'proteomics_MMA132', 'proteomics_MMA133', 'proteomics_MMA134', 'proteomics_MMA135', 'proteomics_MMA136', 'proteomics_MMA137', 'proteomics_MMA138', 'proteomics_MMA139', 'proteomics_MMA140', 'proteomics_MMA141', 'proteomics_MMA142', 'proteomics_MMA143', 'proteomics_MMA144', 'proteomics_MMA145', 'proteomics_MMA146', 'proteomics_MMA147', 'proteomics_MMA148', 'proteomics_MMA149', 'proteomics_MMA150', 'proteomics_MMA151', 'proteomics_MMA152', 'proteomics_MMA153', 'proteomics_MMA154', 'proteomics_MMA155', 'proteomics_MMA156', 'proteomics_MMA157', 'proteomics_MMA158', 'proteomics_MMA159', 'proteomics_MMA160', 'proteomics_MMA161', 'proteomics_MMA162', 'proteomics_MMA163', 'proteomics_MMA164', 'proteomics_MMA165', 'proteomics_MMA166', 'proteomics_MMA167', 'proteomics_MMA168', 'proteomics_MMA169', 'proteomics_MMA170', 'proteomics_MMA171', 'proteomics_MMA172', 'proteomics_MMA173', 'proteomics_MMA174', 'proteomics_MMA175', 'proteomics_MMA176', 'proteomics_MMA177', 'proteomics_MMA178', 'proteomics_MMA179', 'proteomics_MMA180', 'proteomics_MMA181', 'proteomics_MMA182', 'proteomics_MMA183', 'proteomics_MMA184', 'proteomics_MMA185', 'proteomics_MMA186', 'proteomics_MMA187', 'proteomics_MMA188', 'proteomics_MMA189', 'proteomics_MMA190', 'proteomics_MMA191', 'proteomics_MMA192', 'proteomics_MMA193', 'proteomics_MMA194', 'proteomics_MMA195', 'proteomics_MMA196', 'proteomics_MMA197', 'proteomics_MMA198', 'proteomics_MMA199', 'proteomics_MMA200', 'proteomics_MMA201', 'proteomics_MMA202', 'proteomics_MMA203', 'proteomics_MMA204', 'proteomics_MMA205', 'proteomics_MMA206', 'proteomics_MMA207', 'proteomics_MMA208', 'proteomics_MMA209', 'proteomics_MMA210', 'is_proteomics']\n",
             "INFO:__main__:Done\n"
           ]
@@ -1527,7 +1528,7 @@
           "name": "stderr",
           "output_type": "stream",
           "text": [
-            "/var/folders/f1/mcz6x2cj135d8cvtysz3_bfc0000gn/T/ipykernel_86989/1469324662.py:30: FutureWarning: Downcasting object dtype arrays on .fillna, .ffill, .bfill is deprecated and will change in a future version. Call result.infer_objects(copy=False) instead. To opt-in to the future behavior, set `pd.set_option('future.no_silent_downcasting', True)`\n",
+            "/var/folders/f1/mcz6x2cj135d8cvtysz3_bfc0000gn/T/ipykernel_1879/1469324662.py:30: FutureWarning: Downcasting object dtype arrays on .fillna, .ffill, .bfill is deprecated and will change in a future version. Call result.infer_objects(copy=False) instead. To opt-in to the future behavior, set `pd.set_option('future.no_silent_downcasting', True)`\n",
             "  .fillna(False)\n"
           ]
         }
@@ -1576,7 +1577,7 @@
           "name": "stderr",
           "output_type": "stream",
           "text": [
-            "/var/folders/f1/mcz6x2cj135d8cvtysz3_bfc0000gn/T/ipykernel_86989/204630577.py:28: FutureWarning: Downcasting object dtype arrays on .fillna, .ffill, .bfill is deprecated and will change in a future version. Call result.infer_objects(copy=False) instead. To opt-in to the future behavior, set `pd.set_option('future.no_silent_downcasting', True)`\n",
+            "/var/folders/f1/mcz6x2cj135d8cvtysz3_bfc0000gn/T/ipykernel_1879/204630577.py:28: FutureWarning: Downcasting object dtype arrays on .fillna, .ffill, .bfill is deprecated and will change in a future version. Call result.infer_objects(copy=False) instead. To opt-in to the future behavior, set `pd.set_option('future.no_silent_downcasting', True)`\n",
             "  .join(promiscuous_enrichments).fillna(\n"
           ]
         },
@@ -5429,6 +5430,150 @@
       "source": [
         "with pd.option_context('display.max_rows', None, 'display.max_columns', None):\n",
         "    display(attr_enriched_mmut_vertices.sort_values([\"mut_category\", \"modality\", \"log2_enrichment\"], ascending=False))\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "454dffb6",
+      "metadata": {},
+      "source": [
+        "## Export"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 70,
+      "id": "0d27324f",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "from napistu.ontologies.genodexito import Genodexito\n",
+        "from napistu.ontologies.constants import GENODEXITO_DEFS, MYGENE_QUERY_DEFS, ONTOLOGIES\n",
+        "from napistu.ontologies.constants import ONTOLOGIES\n",
+        "\n",
+        "MYGENE_FEATURE_TYPES = [MYGENE_QUERY_DEFS.PROTEIN_CODING, MYGENE_QUERY_DEFS.PSEUDO, MYGENE_QUERY_DEFS.OTHER, MYGENE_QUERY_DEFS.UNKNOWN]\n",
+        "OUTFILE = os.path.join(PROJECT_DIR, \"mma_driver_mutation_rankings.parquet\")"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "acc9a4b6",
+      "metadata": {},
+      "outputs": [
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "INFO:napistu.ontologies.mygene:Creating mapping tables from entrez genes to/from ncbi_entrez_gene, symbol\n",
+            "INFO:napistu.ontologies.mygene:Fetching genome-wide gene data from MyGene...\n",
+            "INFO:httpx:HTTP Request: GET https://mygene.info/v3/query/?species=9606&fields=entrezgene%2Csymbol&fetch_all=true&q=type_of_gene%3Aprotein-coding \"HTTP/1.1 200 OK\"\n",
+            "INFO:httpx:HTTP Request: GET https://mygene.info/v3/query/?species=9606&fields=entrezgene%2Csymbol&scroll_id=FGluY2x1ZGVfY29udGV4dF91dWlkDXF1ZXJ5QW5kRmV0Y2gBFmtwby1pVXRTUzl1Ny05TVZrWkR3VEEAAAAAXIthehZqYnk5R1ZreFQ4NldhN3p3ZE5QeFBR \"HTTP/1.1 200 OK\"\n",
+            "INFO:httpx:HTTP Request: GET https://mygene.info/v3/query/?species=9606&fields=entrezgene%2Csymbol&scroll_id=FGluY2x1ZGVfY29udGV4dF91dWlkDXF1ZXJ5QW5kRmV0Y2gBFmtwby1pVXRTUzl1Ny05TVZrWkR3VEEAAAAAXIthehZqYnk5R1ZreFQ4NldhN3p3ZE5QeFBR \"HTTP/1.1 200 OK\"\n",
+            "INFO:httpx:HTTP Request: GET https://mygene.info/v3/query/?species=9606&fields=entrezgene%2Csymbol&scroll_id=FGluY2x1ZGVfY29udGV4dF91dWlkDXF1ZXJ5QW5kRmV0Y2gBFmtwby1pVXRTUzl1Ny05TVZrWkR3VEEAAAAAXIthehZqYnk5R1ZreFQ4NldhN3p3ZE5QeFBR \"HTTP/1.1 200 OK\"\n",
+            "INFO:httpx:HTTP Request: GET https://mygene.info/v3/query/?species=9606&fields=entrezgene%2Csymbol&scroll_id=FGluY2x1ZGVfY29udGV4dF91dWlkDXF1ZXJ5QW5kRmV0Y2gBFmtwby1pVXRTUzl1Ny05TVZrWkR3VEEAAAAAXIthehZqYnk5R1ZreFQ4NldhN3p3ZE5QeFBR \"HTTP/1.1 200 OK\"\n",
+            "INFO:httpx:HTTP Request: GET https://mygene.info/v3/query/?species=9606&fields=entrezgene%2Csymbol&scroll_id=FGluY2x1ZGVfY29udGV4dF91dWlkDXF1ZXJ5QW5kRmV0Y2gBFmtwby1pVXRTUzl1Ny05TVZrWkR3VEEAAAAAXIthehZqYnk5R1ZreFQ4NldhN3p3ZE5QeFBR \"HTTP/1.1 200 OK\"\n",
+            "INFO:httpx:HTTP Request: GET https://mygene.info/v3/query/?species=9606&fields=entrezgene%2Csymbol&scroll_id=FGluY2x1ZGVfY29udGV4dF91dWlkDXF1ZXJ5QW5kRmV0Y2gBFmtwby1pVXRTUzl1Ny05TVZrWkR3VEEAAAAAXIthehZqYnk5R1ZreFQ4NldhN3p3ZE5QeFBR \"HTTP/1.1 200 OK\"\n",
+            "INFO:httpx:HTTP Request: GET https://mygene.info/v3/query/?species=9606&fields=entrezgene%2Csymbol&scroll_id=FGluY2x1ZGVfY29udGV4dF91dWlkDXF1ZXJ5QW5kRmV0Y2gBFmtwby1pVXRTUzl1Ny05TVZrWkR3VEEAAAAAXIthehZqYnk5R1ZreFQ4NldhN3p3ZE5QeFBR \"HTTP/1.1 200 OK\"\n",
+            "INFO:httpx:HTTP Request: GET https://mygene.info/v3/query/?species=9606&fields=entrezgene%2Csymbol&scroll_id=FGluY2x1ZGVfY29udGV4dF91dWlkDXF1ZXJ5QW5kRmV0Y2gBFmtwby1pVXRTUzl1Ny05TVZrWkR3VEEAAAAAXIthehZqYnk5R1ZreFQ4NldhN3p3ZE5QeFBR \"HTTP/1.1 200 OK\"\n",
+            "INFO:httpx:HTTP Request: GET https://mygene.info/v3/query/?species=9606&fields=entrezgene%2Csymbol&scroll_id=FGluY2x1ZGVfY29udGV4dF91dWlkDXF1ZXJ5QW5kRmV0Y2gBFmtwby1pVXRTUzl1Ny05TVZrWkR3VEEAAAAAXIthehZqYnk5R1ZreFQ4NldhN3p3ZE5QeFBR \"HTTP/1.1 200 OK\"\n",
+            "INFO:httpx:HTTP Request: GET https://mygene.info/v3/query/?species=9606&fields=entrezgene%2Csymbol&scroll_id=FGluY2x1ZGVfY29udGV4dF91dWlkDXF1ZXJ5QW5kRmV0Y2gBFmtwby1pVXRTUzl1Ny05TVZrWkR3VEEAAAAAXIthehZqYnk5R1ZreFQ4NldhN3p3ZE5QeFBR \"HTTP/1.1 200 OK\"\n",
+            "INFO:httpx:HTTP Request: GET https://mygene.info/v3/query/?species=9606&fields=entrezgene%2Csymbol&scroll_id=FGluY2x1ZGVfY29udGV4dF91dWlkDXF1ZXJ5QW5kRmV0Y2gBFmtwby1pVXRTUzl1Ny05TVZrWkR3VEEAAAAAXIthehZqYnk5R1ZreFQ4NldhN3p3ZE5QeFBR \"HTTP/1.1 200 OK\"\n",
+            "INFO:httpx:HTTP Request: GET https://mygene.info/v3/query/?species=9606&fields=entrezgene%2Csymbol&scroll_id=FGluY2x1ZGVfY29udGV4dF91dWlkDXF1ZXJ5QW5kRmV0Y2gBFmtwby1pVXRTUzl1Ny05TVZrWkR3VEEAAAAAXIthehZqYnk5R1ZreFQ4NldhN3p3ZE5QeFBR \"HTTP/1.1 200 OK\"\n",
+            "INFO:httpx:HTTP Request: GET https://mygene.info/v3/query/?species=9606&fields=entrezgene%2Csymbol&scroll_id=FGluY2x1ZGVfY29udGV4dF91dWlkDXF1ZXJ5QW5kRmV0Y2gBFmtwby1pVXRTUzl1Ny05TVZrWkR3VEEAAAAAXIthehZqYnk5R1ZreFQ4NldhN3p3ZE5QeFBR \"HTTP/1.1 200 OK\"\n",
+            "INFO:httpx:HTTP Request: GET https://mygene.info/v3/query/?species=9606&fields=entrezgene%2Csymbol&scroll_id=FGluY2x1ZGVfY29udGV4dF91dWlkDXF1ZXJ5QW5kRmV0Y2gBFmtwby1pVXRTUzl1Ny05TVZrWkR3VEEAAAAAXIthehZqYnk5R1ZreFQ4NldhN3p3ZE5QeFBR \"HTTP/1.1 200 OK\"\n",
+            "INFO:httpx:HTTP Request: GET https://mygene.info/v3/query/?species=9606&fields=entrezgene%2Csymbol&scroll_id=FGluY2x1ZGVfY29udGV4dF91dWlkDXF1ZXJ5QW5kRmV0Y2gBFmtwby1pVXRTUzl1Ny05TVZrWkR3VEEAAAAAXIthehZqYnk5R1ZreFQ4NldhN3p3ZE5QeFBR \"HTTP/1.1 200 OK\"\n",
+            "INFO:httpx:HTTP Request: GET https://mygene.info/v3/query/?species=9606&fields=entrezgene%2Csymbol&scroll_id=FGluY2x1ZGVfY29udGV4dF91dWlkDXF1ZXJ5QW5kRmV0Y2gBFmtwby1pVXRTUzl1Ny05TVZrWkR3VEEAAAAAXIthehZqYnk5R1ZreFQ4NldhN3p3ZE5QeFBR \"HTTP/1.1 200 OK\"\n",
+            "INFO:httpx:HTTP Request: GET https://mygene.info/v3/query/?species=9606&fields=entrezgene%2Csymbol&scroll_id=FGluY2x1ZGVfY29udGV4dF91dWlkDXF1ZXJ5QW5kRmV0Y2gBFmtwby1pVXRTUzl1Ny05TVZrWkR3VEEAAAAAXIthehZqYnk5R1ZreFQ4NldhN3p3ZE5QeFBR \"HTTP/1.1 200 OK\"\n",
+            "INFO:httpx:HTTP Request: GET https://mygene.info/v3/query/?species=9606&fields=entrezgene%2Csymbol&scroll_id=FGluY2x1ZGVfY29udGV4dF91dWlkDXF1ZXJ5QW5kRmV0Y2gBFmtwby1pVXRTUzl1Ny05TVZrWkR3VEEAAAAAXIthehZqYnk5R1ZreFQ4NldhN3p3ZE5QeFBR \"HTTP/1.1 200 OK\"\n",
+            "INFO:httpx:HTTP Request: GET https://mygene.info/v3/query/?species=9606&fields=entrezgene%2Csymbol&scroll_id=FGluY2x1ZGVfY29udGV4dF91dWlkDXF1ZXJ5QW5kRmV0Y2gBFmtwby1pVXRTUzl1Ny05TVZrWkR3VEEAAAAAXIthehZqYnk5R1ZreFQ4NldhN3p3ZE5QeFBR \"HTTP/1.1 200 OK\"\n",
+            "INFO:httpx:HTTP Request: GET https://mygene.info/v3/query/?species=9606&fields=entrezgene%2Csymbol&scroll_id=FGluY2x1ZGVfY29udGV4dF91dWlkDXF1ZXJ5QW5kRmV0Y2gBFmtwby1pVXRTUzl1Ny05TVZrWkR3VEEAAAAAXIthehZqYnk5R1ZreFQ4NldhN3p3ZE5QeFBR \"HTTP/1.1 200 OK\"\n",
+            "INFO:httpx:HTTP Request: GET https://mygene.info/v3/query/?species=9606&fields=entrezgene%2Csymbol&scroll_id=FGluY2x1ZGVfY29udGV4dF91dWlkDXF1ZXJ5QW5kRmV0Y2gBFmtwby1pVXRTUzl1Ny05TVZrWkR3VEEAAAAAXIthehZqYnk5R1ZreFQ4NldhN3p3ZE5QeFBR \"HTTP/1.1 200 OK\"\n",
+            "ERROR:biothings.client:No more results to return.\n",
+            "INFO:napistu.ontologies.mygene:Retrieved 20598 genes from type_of_gene:protein-coding\n",
+            "INFO:httpx:HTTP Request: GET https://mygene.info/v3/query/?species=9606&fields=entrezgene%2Csymbol&fetch_all=true&q=type_of_gene%3Apseudo \"HTTP/1.1 200 OK\"\n",
+            "INFO:httpx:HTTP Request: GET https://mygene.info/v3/query/?species=9606&fields=entrezgene%2Csymbol&scroll_id=FGluY2x1ZGVfY29udGV4dF91dWlkDXF1ZXJ5QW5kRmV0Y2gBFmtwby1pVXRTUzl1Ny05TVZrWkR3VEEAAAAAXItm5BZqYnk5R1ZreFQ4NldhN3p3ZE5QeFBR \"HTTP/1.1 200 OK\"\n",
+            "INFO:httpx:HTTP Request: GET https://mygene.info/v3/query/?species=9606&fields=entrezgene%2Csymbol&scroll_id=FGluY2x1ZGVfY29udGV4dF91dWlkDXF1ZXJ5QW5kRmV0Y2gBFmtwby1pVXRTUzl1Ny05TVZrWkR3VEEAAAAAXItm5BZqYnk5R1ZreFQ4NldhN3p3ZE5QeFBR \"HTTP/1.1 200 OK\"\n",
+            "INFO:httpx:HTTP Request: GET https://mygene.info/v3/query/?species=9606&fields=entrezgene%2Csymbol&scroll_id=FGluY2x1ZGVfY29udGV4dF91dWlkDXF1ZXJ5QW5kRmV0Y2gBFmtwby1pVXRTUzl1Ny05TVZrWkR3VEEAAAAAXItm5BZqYnk5R1ZreFQ4NldhN3p3ZE5QeFBR \"HTTP/1.1 200 OK\"\n",
+            "INFO:httpx:HTTP Request: GET https://mygene.info/v3/query/?species=9606&fields=entrezgene%2Csymbol&scroll_id=FGluY2x1ZGVfY29udGV4dF91dWlkDXF1ZXJ5QW5kRmV0Y2gBFmtwby1pVXRTUzl1Ny05TVZrWkR3VEEAAAAAXItm5BZqYnk5R1ZreFQ4NldhN3p3ZE5QeFBR \"HTTP/1.1 200 OK\"\n",
+            "INFO:httpx:HTTP Request: GET https://mygene.info/v3/query/?species=9606&fields=entrezgene%2Csymbol&scroll_id=FGluY2x1ZGVfY29udGV4dF91dWlkDXF1ZXJ5QW5kRmV0Y2gBFmtwby1pVXRTUzl1Ny05TVZrWkR3VEEAAAAAXItm5BZqYnk5R1ZreFQ4NldhN3p3ZE5QeFBR \"HTTP/1.1 200 OK\"\n",
+            "INFO:httpx:HTTP Request: GET https://mygene.info/v3/query/?species=9606&fields=entrezgene%2Csymbol&scroll_id=FGluY2x1ZGVfY29udGV4dF91dWlkDXF1ZXJ5QW5kRmV0Y2gBFmtwby1pVXRTUzl1Ny05TVZrWkR3VEEAAAAAXItm5BZqYnk5R1ZreFQ4NldhN3p3ZE5QeFBR \"HTTP/1.1 200 OK\"\n",
+            "INFO:httpx:HTTP Request: GET https://mygene.info/v3/query/?species=9606&fields=entrezgene%2Csymbol&scroll_id=FGluY2x1ZGVfY29udGV4dF91dWlkDXF1ZXJ5QW5kRmV0Y2gBFmtwby1pVXRTUzl1Ny05TVZrWkR3VEEAAAAAXItm5BZqYnk5R1ZreFQ4NldhN3p3ZE5QeFBR \"HTTP/1.1 200 OK\"\n",
+            "INFO:httpx:HTTP Request: GET https://mygene.info/v3/query/?species=9606&fields=entrezgene%2Csymbol&scroll_id=FGluY2x1ZGVfY29udGV4dF91dWlkDXF1ZXJ5QW5kRmV0Y2gBFmtwby1pVXRTUzl1Ny05TVZrWkR3VEEAAAAAXItm5BZqYnk5R1ZreFQ4NldhN3p3ZE5QeFBR \"HTTP/1.1 200 OK\"\n",
+            "INFO:httpx:HTTP Request: GET https://mygene.info/v3/query/?species=9606&fields=entrezgene%2Csymbol&scroll_id=FGluY2x1ZGVfY29udGV4dF91dWlkDXF1ZXJ5QW5kRmV0Y2gBFmtwby1pVXRTUzl1Ny05TVZrWkR3VEEAAAAAXItm5BZqYnk5R1ZreFQ4NldhN3p3ZE5QeFBR \"HTTP/1.1 200 OK\"\n",
+            "INFO:httpx:HTTP Request: GET https://mygene.info/v3/query/?species=9606&fields=entrezgene%2Csymbol&scroll_id=FGluY2x1ZGVfY29udGV4dF91dWlkDXF1ZXJ5QW5kRmV0Y2gBFmtwby1pVXRTUzl1Ny05TVZrWkR3VEEAAAAAXItm5BZqYnk5R1ZreFQ4NldhN3p3ZE5QeFBR \"HTTP/1.1 200 OK\"\n",
+            "INFO:httpx:HTTP Request: GET https://mygene.info/v3/query/?species=9606&fields=entrezgene%2Csymbol&scroll_id=FGluY2x1ZGVfY29udGV4dF91dWlkDXF1ZXJ5QW5kRmV0Y2gBFmtwby1pVXRTUzl1Ny05TVZrWkR3VEEAAAAAXItm5BZqYnk5R1ZreFQ4NldhN3p3ZE5QeFBR \"HTTP/1.1 200 OK\"\n",
+            "INFO:httpx:HTTP Request: GET https://mygene.info/v3/query/?species=9606&fields=entrezgene%2Csymbol&scroll_id=FGluY2x1ZGVfY29udGV4dF91dWlkDXF1ZXJ5QW5kRmV0Y2gBFmtwby1pVXRTUzl1Ny05TVZrWkR3VEEAAAAAXItm5BZqYnk5R1ZreFQ4NldhN3p3ZE5QeFBR \"HTTP/1.1 200 OK\"\n",
+            "INFO:httpx:HTTP Request: GET https://mygene.info/v3/query/?species=9606&fields=entrezgene%2Csymbol&scroll_id=FGluY2x1ZGVfY29udGV4dF91dWlkDXF1ZXJ5QW5kRmV0Y2gBFmtwby1pVXRTUzl1Ny05TVZrWkR3VEEAAAAAXItm5BZqYnk5R1ZreFQ4NldhN3p3ZE5QeFBR \"HTTP/1.1 200 OK\"\n",
+            "INFO:httpx:HTTP Request: GET https://mygene.info/v3/query/?species=9606&fields=entrezgene%2Csymbol&scroll_id=FGluY2x1ZGVfY29udGV4dF91dWlkDXF1ZXJ5QW5kRmV0Y2gBFmtwby1pVXRTUzl1Ny05TVZrWkR3VEEAAAAAXItm5BZqYnk5R1ZreFQ4NldhN3p3ZE5QeFBR \"HTTP/1.1 200 OK\"\n",
+            "INFO:httpx:HTTP Request: GET https://mygene.info/v3/query/?species=9606&fields=entrezgene%2Csymbol&scroll_id=FGluY2x1ZGVfY29udGV4dF91dWlkDXF1ZXJ5QW5kRmV0Y2gBFmtwby1pVXRTUzl1Ny05TVZrWkR3VEEAAAAAXItm5BZqYnk5R1ZreFQ4NldhN3p3ZE5QeFBR \"HTTP/1.1 200 OK\"\n",
+            "INFO:httpx:HTTP Request: GET https://mygene.info/v3/query/?species=9606&fields=entrezgene%2Csymbol&scroll_id=FGluY2x1ZGVfY29udGV4dF91dWlkDXF1ZXJ5QW5kRmV0Y2gBFmtwby1pVXRTUzl1Ny05TVZrWkR3VEEAAAAAXItm5BZqYnk5R1ZreFQ4NldhN3p3ZE5QeFBR \"HTTP/1.1 200 OK\"\n",
+            "INFO:httpx:HTTP Request: GET https://mygene.info/v3/query/?species=9606&fields=entrezgene%2Csymbol&scroll_id=FGluY2x1ZGVfY29udGV4dF91dWlkDXF1ZXJ5QW5kRmV0Y2gBFmtwby1pVXRTUzl1Ny05TVZrWkR3VEEAAAAAXItm5BZqYnk5R1ZreFQ4NldhN3p3ZE5QeFBR \"HTTP/1.1 200 OK\"\n",
+            "INFO:httpx:HTTP Request: GET https://mygene.info/v3/query/?species=9606&fields=entrezgene%2Csymbol&scroll_id=FGluY2x1ZGVfY29udGV4dF91dWlkDXF1ZXJ5QW5kRmV0Y2gBFmtwby1pVXRTUzl1Ny05TVZrWkR3VEEAAAAAXItm5BZqYnk5R1ZreFQ4NldhN3p3ZE5QeFBR \"HTTP/1.1 200 OK\"\n",
+            "ERROR:biothings.client:No more results to return.\n",
+            "INFO:napistu.ontologies.mygene:Retrieved 17498 genes from type_of_gene:pseudo\n",
+            "INFO:httpx:HTTP Request: GET https://mygene.info/v3/query/?species=9606&fields=entrezgene%2Csymbol&fetch_all=true&q=type_of_gene%3Aother \"HTTP/1.1 200 OK\"\n",
+            "INFO:httpx:HTTP Request: GET https://mygene.info/v3/query/?species=9606&fields=entrezgene%2Csymbol&scroll_id=FGluY2x1ZGVfY29udGV4dF91dWlkDXF1ZXJ5QW5kRmV0Y2gBFjg0Z0JQdlBPUmE2UGFURl9xc2Zvb1EAAAABApt6NhZhdXNFODVPZVJBaVVlLVNKRW9QZDVB \"HTTP/1.1 200 OK\"\n",
+            "ERROR:biothings.client:No more results to return.\n",
+            "INFO:napistu.ontologies.mygene:Retrieved 844 genes from type_of_gene:other\n",
+            "INFO:httpx:HTTP Request: GET https://mygene.info/v3/query/?species=9606&fields=entrezgene%2Csymbol&fetch_all=true&q=type_of_gene%3Aunknown \"HTTP/1.1 200 OK\"\n",
+            "INFO:httpx:HTTP Request: GET https://mygene.info/v3/query/?species=9606&fields=entrezgene%2Csymbol&scroll_id=FGluY2x1ZGVfY29udGV4dF91dWlkDXF1ZXJ5QW5kRmV0Y2gBFmVpN01tbExtUVRxWlFTOVVzcEZSR0EAAAABRk4pOBYxQkRzdGluUlRZZWFOczlwS3plcHRn \"HTTP/1.1 200 OK\"\n",
+            "INFO:httpx:HTTP Request: GET https://mygene.info/v3/query/?species=9606&fields=entrezgene%2Csymbol&scroll_id=FGluY2x1ZGVfY29udGV4dF91dWlkDXF1ZXJ5QW5kRmV0Y2gBFmVpN01tbExtUVRxWlFTOVVzcEZSR0EAAAABRk4pOBYxQkRzdGluUlRZZWFOczlwS3plcHRn \"HTTP/1.1 200 OK\"\n",
+            "ERROR:biothings.client:No more results to return.\n",
+            "INFO:napistu.ontologies.mygene:Retrieved 1196 genes from type_of_gene:unknown\n",
+            "INFO:napistu.ontologies.mygene:Retrieved 40136 genes and RNAs\n",
+            "INFO:napistu.ontologies.mygene:Processing field: entrezgene\n",
+            "INFO:napistu.ontologies.mygene:Processing field: symbol\n"
+          ]
+        }
+      ],
+      "source": [
+        "# build an Symbol <-> NCBI Entrez mapping table since variants are annotated based on HGNC symbols\n",
+        "genodexito = Genodexito(\n",
+        "    preferred_method = GENODEXITO_DEFS.PYTHON,\n",
+        "    mygene_query_strategies = MYGENE_FEATURE_TYPES,\n",
+        ")\n",
+        "genodexito.create_mapping_tables(mappings = {\"symbol\", \"ncbi_entrez_gene\"})\n",
+        "genodexito.merge_mappings()"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 43,
+      "id": "36c11f32",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "sids_to_symbols = (\n",
+        "    species_identifiers.query(f\"ontology == '{ONTOLOGIES.NCBI_ENTREZ_GENE}'\")\n",
+        "    .rename(columns = {\"identifier\": ONTOLOGIES.NCBI_ENTREZ_GENE})\n",
+        "    .merge(genodexito.merged_mappings, on = ONTOLOGIES.NCBI_ENTREZ_GENE, how = \"left\")\n",
+        ")\n",
+        "\n",
+        "# 24 entries don't have symbols so just adding their names - this recovers all but a couple of entries\n",
+        "sids_to_symbols[\"sybmol\"] = [\n",
+        "    x if x is not np.nan else y for x, y in zip(sids_to_symbols[\"symbol\"], sids_to_symbols[\"s_name\"])\n",
+        "]"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 71,
+      "id": "24a947e2",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "output = (\n",
+        "    personalized_ranks[[\"vertex\", \"modality\", \"attribute\", \"log2_enrichment\", \"attribute_rank\"]]\n",
+        "    .rename(columns = {\"attribute\" : \"patient\"})\n",
+        "    .merge(vertex_metadata[[\"vertex\", \"s_id\"]], on = \"vertex\", how = \"left\")    \n",
+        "    .merge(sids_to_symbols[[\"s_id\", \"symbol\"]], on = \"s_id\", how = \"inner\")\n",
+        "    .drop(columns = [\"s_id\", \"vertex\"])\n",
+        "    [[\"patient\", \"modality\", \"symbol\", \"log2_enrichment\", \"attribute_rank\"]]\n",
+        "    .sort_values([\"patient\", \"modality\", \"attribute_rank\"])\n",
+        ")\n",
+        "\n",
+        "output.to_parquet(OUTFILE)\n"
       ]
     }
   ],


### PR DESCRIPTION
Extended driver ranking notebook to export a table with patient, modality, gene symbol, rank (based on patient-level PPR) and log2 enrichment (of vertex-level signals relative to their permutation-based null distribution).